### PR TITLE
ft/003-expand-cancel-buttons to dev

### DIFF
--- a/css/main.css
+++ b/css/main.css
@@ -87,8 +87,8 @@ span.close{
 	position: absolute;
 	top:-10px;
 	right: -10px;
-	width: 2%;
-	height: 2.2%;
+	width: 5%;
+	height: 5.5%;
 	margin: 3%;
 	background: url('../img/icon-close.png') no-repeat;
 	background-size: 100% 100%;
@@ -343,11 +343,11 @@ span.close:hover{
 	background-size: 100% 100%;
 }
 .iframeBox #iframe{
-	width: 92%;
-	height: 91%;
+	width: 88%;
+	height: 87%;
 	position: absolute;
-	top: 6%;
-	left: 4%;
+	top: 9%;
+	left: 5%;
 }
 .iframeBox #iframe iframe,.iframeBox #iframe video{
 	width: 100%;


### PR DESCRIPTION
I made the cancel buttons bigger because people have had a hard time tapping precisely enough to hit them. I then went through and checked what the new size may have altered and saw that selecting a video covered part of the now bigger cancel button. I shrank and shifted the video slightly to both make room for and compliment the cancel button. I edited EMT according to my findings with the dev tools, built the new war, then uploaded it to the server, and saw that it ran nicely.